### PR TITLE
Fix: Mobile link bug

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -218,7 +218,7 @@ function displayEvents(){
             var obj = $(this);
             var currentDay = obj.data("d");
             var currentHTML = obj.html();
-            obj.attr("href", "#");
+            obj.attr("href", "javascript:void(0)");
             obj.attr("target", "");
             obj.html(obj.data("d") + " | " + currentHTML + "<hr>");
         });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,6 +9,7 @@
         <meta name="theme-color" content="#B0197E">
         <!-- Linking to stylesheets, scriptsheets, and apis -->
         <link rel="stylesheet" href="https://assets.csh.rit.edu/csh-material-bootstrap/3.3.6/dist/csh-material-bootstrap.min.css">
+        <link rel="shortcut icon" href="https://assets.csh.rit.edu/uploads/favicon.ico" type="image/x-icon">
 
         <!-- Bootstrap CSS library -->
         <link rel="stylesheet" href=


### PR DESCRIPTION
Mobile V no longer resets to the top of the page if you click on a link